### PR TITLE
Fix refresh cookie settings for cross-domain in browser

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -11,10 +11,14 @@ const setupSession = (res, session) => {
   res.cookie('refreshToken', session.refreshToken, {
     httpOnly: true,
     expires: session.refreshTokenValidUntil,
+    secure: true,
+    sameSite: 'none',
   });
   res.cookie('sessionId', session._id, {
     httpOnly: true,
     expires: session.refreshTokenValidUntil,
+    secure: true,
+    sameSite: 'none',
   });
 };
 


### PR DESCRIPTION
- Added `secure: true` to refresh cookie (required for HTTPS in production)
- Added `sameSite: 'none'` to allow sending cookies across domains